### PR TITLE
Minor update to the Variables section to BASH cheat sheet.

### DIFF
--- a/bash.md
+++ b/bash.md
@@ -48,7 +48,7 @@ Generally quote your variables unless they contain wildcards to expand or comman
 
 ```bash
 wildcard="*.txt"
-option="iv"
+options="iv"
 cp -$options $wildcard /tmp
 ```
 


### PR DESCRIPTION
New users might get confused when this example doesn't work because of the lack of "s" for the options variable.